### PR TITLE
Fix imports, use topic_patch, distinguish PublisherClient vs Subscrib…

### DIFF
--- a/sdks/python/apache_beam/io/gcp/pubsub.py
+++ b/sdks/python/apache_beam/io/gcp/pubsub.py
@@ -40,7 +40,7 @@ from apache_beam.utils.annotations import deprecated
 
 # The protobuf library is only used for running on Dataflow.
 try:
-  from google.cloud.proto.pubsub.v1 import pubsub_pb2
+  from google.cloud.pubsub_v1.proto import pubsub_pb2
 except ImportError:
   pubsub_pb2 = None
 
@@ -98,22 +98,28 @@ class PubsubMessage(object):
     attributes = dict((key, msg.attributes[key]) for key in msg.attributes)
     return PubsubMessage(msg.data, attributes)
 
-  def _to_proto_str(self):
-    """Get serialized form of ``PubsubMessage``.
+  def _to_proto(self):
+    """Return a new protobuf of type
+      https://cloud.google.com/pubsub/docs/reference/rpc/google.pubsub.v1#google.pubsub.v1.PubsubMessage
+      containing the payload of this object.
+    """
+    msg = pubsub_pb2.PubsubMessage()
+    if self.data:
+      msg.data = self.data
+    if self.attributes:
+      for key, value in self.attributes.iteritems():
+        msg.attributes[key] = value
+    return msg
 
-    Args:
-      proto_msg: str containing a serialized protobuf.
+  def _to_proto_str(self):
+    """Return a serialized form of this ``PubsubMessage``.
 
     Returns:
       A str containing a serialized protobuf of type
       https://cloud.google.com/pubsub/docs/reference/rpc/google.pubsub.v1#google.pubsub.v1.PubsubMessage
       containing the payload of this object.
     """
-    msg = pubsub_pb2.PubsubMessage()
-    msg.data = self.data
-    for key, value in self.attributes.iteritems():
-      msg.attributes[key] = value
-    return msg.SerializeToString()
+    return self._to_proto().SerializeToString()
 
   @staticmethod
   def _from_message(msg):

--- a/sdks/python/apache_beam/io/gcp/pubsub_test.py
+++ b/sdks/python/apache_beam/io/gcp/pubsub_test.py
@@ -63,7 +63,7 @@ except ImportError:
 
 # The protobuf library is only used for running on Dataflow.
 try:
-  from google.cloud.proto.pubsub.v1 import pubsub_pb2
+  from google.cloud.pubsub_v1.proto import pubsub_pb2
 except ImportError:
   pubsub_pb2 = None
 
@@ -422,8 +422,11 @@ def create_client_message(data, message_id, attributes, publish_time):
 
   This is what the reader sees.
   """
-  msg = pubsub.message.Message(data, message_id, attributes)
-  msg._service_timestamp = publish_time
+  msg = PubsubMessage(data, attributes)._to_proto()
+  if message_id:
+    msg.message_id = message_id
+  if publish_time:
+    msg.publish_time.FromJsonString(publish_time)
   return msg
 
 

--- a/sdks/python/apache_beam/io/gcp/tests/pubsub_matcher.py
+++ b/sdks/python/apache_beam/io/gcp/tests/pubsub_matcher.py
@@ -33,7 +33,7 @@ __all__ = ['PubSubMessageMatcher']
 # Protect against environments where pubsub library is not available.
 # pylint: disable=wrong-import-order, wrong-import-position
 try:
-  from google.cloud import pubsub
+  from google.cloud import pubsub_v1 as pubsub
 except ImportError:
   pubsub = None
 # pylint: enable=wrong-import-order, wrong-import-position
@@ -92,11 +92,14 @@ class PubSubMessageMatcher(BaseMatcher):
     return Counter(self.messages) == Counter(self.expected_msg)
 
   def _get_subscription(self):
-    return pubsub.Client(project=self.project).subscription(self.sub_name)
+    client = pubsub.SubscriberClient()
+    topic = client.topic_path(self.project, 'pubsub-matcher')
+    return pubsub.SubscriberClient().create_subscription(self.sub_name, topic)
 
   def _wait_for_messages(self, subscription, expected_num, timeout):
     """Wait for messages from given subscription."""
     logging.debug('Start pulling messages from %s', subscription.full_name)
+    XXX
     total_messages = []
     start_time = time.time()
     while time.time() - start_time <= timeout:

--- a/sdks/python/apache_beam/runners/direct/transform_evaluator.py
+++ b/sdks/python/apache_beam/runners/direct/transform_evaluator.py
@@ -444,7 +444,7 @@ class _PubSubReadEvaluator(_TransformEvaluator):
             except ValueError as e:
               raise ValueError('Bad timestamp value: %s' % e)
         else:
-          timestamp = Timestamp.from_rfc3339(message.service_timestamp)
+          timestamp = Timestamp.from_rfc3339(message.publish_time.ToJsonString())
 
         return timestamp, parsed_message
 


### PR DESCRIPTION
…erClient

This is partial work to get PubSub working.  I developed against pubsub 0.37.2

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

It will help us expedite review of your Pull Request if you tag someone (e.g. `@username`) to look at it.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | --- | --- | --- | ---




